### PR TITLE
add lib fn to create proposal attestation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
 SESSION_KEY=+++DEV++++++++++++++++++++++++++++++++++++++
+ATTESTER_PRIVATE_KEY=0x

--- a/packages/server/db/index.ts
+++ b/packages/server/db/index.ts
@@ -16,6 +16,8 @@ export type Proposal = O.NonNullable<DraftProposal,
   | "eligibility_type"
 >;
 
+export type CompletedProposal = O.Nullable<Proposal, "uid">;
+
 const dialect = new PostgresDialect({
   pool: new Pool({
     connectionString: process.env.DATABASE_URL,

--- a/packages/server/lib/abi.ts
+++ b/packages/server/lib/abi.ts
@@ -1,0 +1,1136 @@
+import { Hex, decodeAbiParameters, parseAbiParameters } from 'viem';
+
+export function decodeParameters(schema: string, data: Hex) {
+  return decodeAbiParameters(parseAbiParameters(schema), data);
+}
+
+export const EAS = [
+  {
+    inputs: [
+      {
+        internalType: 'contract ISchemaRegistry',
+        name: 'registry',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [],
+    name: 'AccessDenied',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'AlreadyRevoked',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'AlreadyRevokedOffchain',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'AlreadyTimestamped',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InsufficientValue',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidAttestation',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidAttestations',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidExpirationTime',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidLength',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidOffset',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidRegistry',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidRevocation',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidRevocations',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidSchema',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidSignature',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidVerifier',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'Irrevocable',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NotFound',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NotPayable',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'WrongSchema',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'attester',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'uid',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'schema',
+        type: 'bytes32',
+      },
+    ],
+    name: 'Attested',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'attester',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'uid',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'schema',
+        type: 'bytes32',
+      },
+    ],
+    name: 'Revoked',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'revoker',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'data',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'uint64',
+        name: 'timestamp',
+        type: 'uint64',
+      },
+    ],
+    name: 'RevokedOffchain',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'data',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'uint64',
+        name: 'timestamp',
+        type: 'uint64',
+      },
+    ],
+    name: 'Timestamped',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'VERSION',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'schema',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'address',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                internalType: 'uint64',
+                name: 'expirationTime',
+                type: 'uint64',
+              },
+              {
+                internalType: 'bool',
+                name: 'revocable',
+                type: 'bool',
+              },
+              {
+                internalType: 'bytes32',
+                name: 'refUID',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'bytes',
+                name: 'data',
+                type: 'bytes',
+              },
+              {
+                internalType: 'uint256',
+                name: 'value',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct AttestationRequestData',
+            name: 'data',
+            type: 'tuple',
+          },
+        ],
+        internalType: 'struct AttestationRequest',
+        name: 'request',
+        type: 'tuple',
+      },
+    ],
+    name: 'attest',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'schema',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'address',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                internalType: 'uint64',
+                name: 'expirationTime',
+                type: 'uint64',
+              },
+              {
+                internalType: 'bool',
+                name: 'revocable',
+                type: 'bool',
+              },
+              {
+                internalType: 'bytes32',
+                name: 'refUID',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'bytes',
+                name: 'data',
+                type: 'bytes',
+              },
+              {
+                internalType: 'uint256',
+                name: 'value',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct AttestationRequestData',
+            name: 'data',
+            type: 'tuple',
+          },
+          {
+            components: [
+              {
+                internalType: 'uint8',
+                name: 'v',
+                type: 'uint8',
+              },
+              {
+                internalType: 'bytes32',
+                name: 'r',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'bytes32',
+                name: 's',
+                type: 'bytes32',
+              },
+            ],
+            internalType: 'struct EIP712Signature',
+            name: 'signature',
+            type: 'tuple',
+          },
+          {
+            internalType: 'address',
+            name: 'attester',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct DelegatedAttestationRequest',
+        name: 'delegatedRequest',
+        type: 'tuple',
+      },
+    ],
+    name: 'attestByDelegation',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getAttestTypeHash',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'uid',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getAttestation',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'uid',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'schema',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'uint64',
+            name: 'time',
+            type: 'uint64',
+          },
+          {
+            internalType: 'uint64',
+            name: 'expirationTime',
+            type: 'uint64',
+          },
+          {
+            internalType: 'uint64',
+            name: 'revocationTime',
+            type: 'uint64',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'refUID',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'address',
+            name: 'recipient',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'attester',
+            type: 'address',
+          },
+          {
+            internalType: 'bool',
+            name: 'revocable',
+            type: 'bool',
+          },
+          {
+            internalType: 'bytes',
+            name: 'data',
+            type: 'bytes',
+          },
+        ],
+        internalType: 'struct Attestation',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getDomainSeparator',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'getNonce',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'revoker',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'data',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getRevokeOffchain',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getRevokeTypeHash',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getSchemaRegistry',
+    outputs: [
+      {
+        internalType: 'contract ISchemaRegistry',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'data',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getTimestamp',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'uid',
+        type: 'bytes32',
+      },
+    ],
+    name: 'isAttestationValid',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'schema',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'address',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                internalType: 'uint64',
+                name: 'expirationTime',
+                type: 'uint64',
+              },
+              {
+                internalType: 'bool',
+                name: 'revocable',
+                type: 'bool',
+              },
+              {
+                internalType: 'bytes32',
+                name: 'refUID',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'bytes',
+                name: 'data',
+                type: 'bytes',
+              },
+              {
+                internalType: 'uint256',
+                name: 'value',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct AttestationRequestData[]',
+            name: 'data',
+            type: 'tuple[]',
+          },
+        ],
+        internalType: 'struct MultiAttestationRequest[]',
+        name: 'multiRequests',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'multiAttest',
+    outputs: [
+      {
+        internalType: 'bytes32[]',
+        name: '',
+        type: 'bytes32[]',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'schema',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'address',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                internalType: 'uint64',
+                name: 'expirationTime',
+                type: 'uint64',
+              },
+              {
+                internalType: 'bool',
+                name: 'revocable',
+                type: 'bool',
+              },
+              {
+                internalType: 'bytes32',
+                name: 'refUID',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'bytes',
+                name: 'data',
+                type: 'bytes',
+              },
+              {
+                internalType: 'uint256',
+                name: 'value',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct AttestationRequestData[]',
+            name: 'data',
+            type: 'tuple[]',
+          },
+          {
+            components: [
+              {
+                internalType: 'uint8',
+                name: 'v',
+                type: 'uint8',
+              },
+              {
+                internalType: 'bytes32',
+                name: 'r',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'bytes32',
+                name: 's',
+                type: 'bytes32',
+              },
+            ],
+            internalType: 'struct EIP712Signature[]',
+            name: 'signatures',
+            type: 'tuple[]',
+          },
+          {
+            internalType: 'address',
+            name: 'attester',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct MultiDelegatedAttestationRequest[]',
+        name: 'multiDelegatedRequests',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'multiAttestByDelegation',
+    outputs: [
+      {
+        internalType: 'bytes32[]',
+        name: '',
+        type: 'bytes32[]',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'schema',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'bytes32',
+                name: 'uid',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'uint256',
+                name: 'value',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct RevocationRequestData[]',
+            name: 'data',
+            type: 'tuple[]',
+          },
+        ],
+        internalType: 'struct MultiRevocationRequest[]',
+        name: 'multiRequests',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'multiRevoke',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'schema',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'bytes32',
+                name: 'uid',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'uint256',
+                name: 'value',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct RevocationRequestData[]',
+            name: 'data',
+            type: 'tuple[]',
+          },
+          {
+            components: [
+              {
+                internalType: 'uint8',
+                name: 'v',
+                type: 'uint8',
+              },
+              {
+                internalType: 'bytes32',
+                name: 'r',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'bytes32',
+                name: 's',
+                type: 'bytes32',
+              },
+            ],
+            internalType: 'struct EIP712Signature[]',
+            name: 'signatures',
+            type: 'tuple[]',
+          },
+          {
+            internalType: 'address',
+            name: 'revoker',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct MultiDelegatedRevocationRequest[]',
+        name: 'multiDelegatedRequests',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'multiRevokeByDelegation',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32[]',
+        name: 'data',
+        type: 'bytes32[]',
+      },
+    ],
+    name: 'multiRevokeOffchain',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32[]',
+        name: 'data',
+        type: 'bytes32[]',
+      },
+    ],
+    name: 'multiTimestamp',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'schema',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'bytes32',
+                name: 'uid',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'uint256',
+                name: 'value',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct RevocationRequestData',
+            name: 'data',
+            type: 'tuple',
+          },
+        ],
+        internalType: 'struct RevocationRequest',
+        name: 'request',
+        type: 'tuple',
+      },
+    ],
+    name: 'revoke',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'schema',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'bytes32',
+                name: 'uid',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'uint256',
+                name: 'value',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct RevocationRequestData',
+            name: 'data',
+            type: 'tuple',
+          },
+          {
+            components: [
+              {
+                internalType: 'uint8',
+                name: 'v',
+                type: 'uint8',
+              },
+              {
+                internalType: 'bytes32',
+                name: 'r',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'bytes32',
+                name: 's',
+                type: 'bytes32',
+              },
+            ],
+            internalType: 'struct EIP712Signature',
+            name: 'signature',
+            type: 'tuple',
+          },
+          {
+            internalType: 'address',
+            name: 'revoker',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct DelegatedRevocationRequest',
+        name: 'delegatedRequest',
+        type: 'tuple',
+      },
+    ],
+    name: 'revokeByDelegation',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'data',
+        type: 'bytes32',
+      },
+    ],
+    name: 'revokeOffchain',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'data',
+        type: 'bytes32',
+      },
+    ],
+    name: 'timestamp',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
+export const SCHEMA_REGISTRY = [
+  {
+    inputs: [],
+    name: 'AlreadyExists',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'uid',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'registerer',
+        type: 'address',
+      },
+    ],
+    name: 'Registered',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'VERSION',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'uid',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getSchema',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'uid',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'contract ISchemaResolver',
+            name: 'resolver',
+            type: 'address',
+          },
+          {
+            internalType: 'bool',
+            name: 'revocable',
+            type: 'bool',
+          },
+          {
+            internalType: 'string',
+            name: 'schema',
+            type: 'string',
+          },
+        ],
+        internalType: 'struct SchemaRecord',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'schema',
+        type: 'string',
+      },
+      {
+        internalType: 'contract ISchemaResolver',
+        name: 'resolver',
+        type: 'address',
+      },
+      {
+        internalType: 'bool',
+        name: 'revocable',
+        type: 'bool',
+      },
+    ],
+    name: 'register',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;

--- a/packages/server/lib/eas.ts
+++ b/packages/server/lib/eas.ts
@@ -1,0 +1,62 @@
+import { Hex, encodeAbiParameters, getContract, pad, parseAbiParameters } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { getUnixTime } from "date-fns";
+
+import { CompletedProposal } from "@snapcaster/server/db";
+import { publicClient, walletClient } from "./rpc";
+import { EAS } from "./abi";
+import { Selectable } from "kysely";
+
+const EAS_ADDRESS = "0x4200000000000000000000000000000000000021";
+
+const PROPOSAL_SCHEMA = {
+  uid: "0xf3c83d778e0ccde8dcc959ad907f5c7e82a05728a3a4eafc7370138bc8b003e8",
+  schema: "string title,bytes32 summary,bytes32 description,uint64 startTimestamp,uint64 endTimestamp,string eligibilityType,address eligibilityContract,uint256 eligibilityThreshold",
+} as const;
+
+const getEASContract = () => {
+  return getContract({
+    address: EAS_ADDRESS,
+    abi: EAS,
+    client: {
+      public: publicClient,
+      wallet: walletClient,
+    }
+  })
+}
+
+export async function createProposalAttestation(proposal: Selectable<CompletedProposal>) {
+  const eas = getEASContract();
+  const args = [
+    proposal.title,
+    pad(`0x${Buffer.from(proposal.summary || "").toString("hex")}`),
+    pad(`0x${Buffer.from(proposal.description || "").toString("hex")}`),
+    BigInt(getUnixTime(proposal.start_timestamp)),
+    BigInt(getUnixTime(proposal.end_timestamp)),
+    proposal.eligibility_type,
+    (proposal.eligibility_contract || "0x0000000000000000000000000000000000000000") as Hex,
+    BigInt(proposal.eligibility_threshold || 0),
+  ] as const;
+
+  const data = encodeAbiParameters(
+    parseAbiParameters(PROPOSAL_SCHEMA.schema),
+    args,
+  );
+
+  const uid = await eas.write.attest([{
+    schema: PROPOSAL_SCHEMA.uid,
+    data: {
+      data,
+      recipient: "0x0000000000000000000000000000000000000000",
+      revocable: false,
+      expirationTime: 0n,
+      value: 0n,
+      refUID: pad("0x0")
+    }
+  }], {
+    value: 0n,
+    account: privateKeyToAccount(process.env.ATTESTER_PRIVATE_KEY as Hex),
+  });
+
+  return uid;
+}

--- a/packages/server/lib/rpc.ts
+++ b/packages/server/lib/rpc.ts
@@ -1,0 +1,12 @@
+import { createPublicClient, createWalletClient, http } from "viem";
+import { baseSepolia } from "viem/chains";
+
+export const publicClient = createPublicClient({
+  chain: baseSepolia,
+  transport: http(process.env.RPC_URL as string),
+});
+
+export const walletClient = createWalletClient({
+  chain: baseSepolia,
+  transport: http(process.env.RPC_URL as string),
+});

--- a/packages/server/migrations/20240228T020053-proposal-bigint.ts
+++ b/packages/server/migrations/20240228T020053-proposal-bigint.ts
@@ -1,0 +1,15 @@
+import { Kysely } from "kysely"
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("proposal")
+    .alterColumn("eligibility_threshold", (c) => c.setDataType("numeric(78, 0)"))
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("proposal")
+    .alterColumn("eligibility_threshold", (c) => c.setDataType("bigint"))
+    .execute();
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,7 @@
     "@sinclair/typebox": "^0.32.14",
     "@types/node": "^20.11.20",
     "@types/pg": "^8.11.1",
+    "date-fns": "^3.3.1",
     "esbuild": "^0.20.1",
     "fastify": "^4.26.1",
     "kysely": "^0.27.2",
@@ -23,6 +24,7 @@
     "pg": "^8.11.3",
     "ts-toolbelt": "^9.6.0",
     "tsx": "^4.7.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "viem": "^2.7.15"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,8 @@
     "noFallthroughCasesInSwitch": true,
     "outDir": "build"
   },
-  "include": ["server"]
+  "include": [
+    "packages/**/*.ts",
+    "packages/**/*.tsx"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,6 +967,11 @@ csstype@^3.0.2, csstype@^3.0.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+date-fns@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.3.1.tgz#7581daca0892d139736697717a168afbb908cfed"
+  integrity sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==
+
 debug@^4, debug@^4.0.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"


### PR DESCRIPTION
* change db type for eligibility threshold to numeric
* hard-coded network to base sepolia
* hard-coded schema uid
* added ATTESTER_PRIVATE_KEY env var for sending transactions. we will replace this with a different implementation later

example: https://base-sepolia.easscan.org/attestation/view/0x5d712a7c16739c02b425ad6df0a9bd04097956bbd2b43fbe2a48b1ae01739f97